### PR TITLE
Update cargo build options

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
      build:
       context: .
       dockerfile: docker/netmuxd.dockerfile
-     command: sh -c "[ ! -f /build/netmuxd ] && cargo build && cp target/debug/netmuxd /build/ && chmod +x /build/netmuxd || return 0"
+     command: sh -c "[ ! -f /build/netmuxd ] && cargo build --release --features zeroconf && cp target/debug/netmuxd /build/ && chmod +x /build/netmuxd || return 0"
      image: netmuxd:latest
      volumes: 
       - ./bin:/build


### PR DESCRIPTION
This will make netmuxd perform MUCH better in terms of speed and efficiency. Zeroconf is the recommended backend when you're building for the host system, mDNS is just the fallback because zeroconf requires a dylib. I see that you're already cloning it, so you might as well use it.